### PR TITLE
BUGFIX: Use matching guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "neos/neos": "^4.0",
-        "guzzlehttp/guzzle": "^5.1"
+        "guzzlehttp/guzzle": "^6.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The previously referenced guzzle version 5.x doesn't support `Client->request`