### PR TITLE
Bugfix: Make sure a string is returned from result

### DIFF
--- a/Classes/Api/PexelsClient.php
+++ b/Classes/Api/PexelsClient.php
@@ -148,7 +148,7 @@ final class PexelsClient
         if (!isset($this->queryResults[$requestIdentifier])) {
             $result = $this->getClient()->request('GET', self::API_URL . $type . '?' . http_build_query($requestParameter));
 
-            $resultArray = \GuzzleHttp\json_decode($result->getBody(), true);
+            $resultArray = \GuzzleHttp\json_decode($result->getBody()->getContents(), true);
             $this->queryResults[$requestIdentifier] = $this->processResult($resultArray);
         }
 


### PR DESCRIPTION
Without this change, I get following error:

```
Argument 1 passed to GuzzleHttp\json_decode() must be of the type string, object given, called in /Data/Temporary/Development/Cache/Code/Flow_Object_Classes/DL_AssetSource_Pexels_Api_PexelsClient.php on line 152
```

```
GuzzleHttp\json_decode(GuzzleHttp\Psr7\Stream, true)
Data/Temporary/Development/Cache/Code/Flow_Object_Classes/DL_AssetSource_Pexels_Api_PexelsClient.php
Original File: Packages/Application/DL.AssetSource.Pexels/Classes/Api/PexelsClient.php

$result = $this->getClient()->request('GET', self::API_URL . $type . '?' . http_build_query($requestParameter));
$resultArray = \GuzzleHttp\json_decode($result->getBody(), true);
$this->queryResults[$requestIdentifier] = $this->processResult($resultArray);
```

As `json_decode` need a string, I called also `getContents` to ensure we will have a string and not a `StreamInterface`